### PR TITLE
add the privacy plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 tanssi-docs*
 venv
 .DS_Store
+.cache

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -62,6 +62,7 @@
   - 'awesome-pages'
   - 'git-revision-date-localized':
       'enable_creation_date': !!bool 'true'
+  - 'privacy'
   - 'redirects':
       'redirect_maps':
         # Redirects will go here as pages get moved around in the following format:


### PR DESCRIPTION
This PR adds the privacy plugin to the docs site; what this does is download all external assets and self-host them. The external assets that are downloaded can be scripts, style sheets, JSON files, images, and web fonts.

At this point in time, it benefits us by downloading and caching fonts. It can also provide additional benefits down the road if we add any more external assets.

Generally speaking, this can improve load performance.

As a side note, it's called the privacy plugin because it was designed to comply with the 2018 European General Data Protection Regulation (GDPR). More information can be found here: https://squidfunk.github.io/mkdocs-material/plugins/privacy/