### PR TITLE
remove the termynal js

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,7 +7,6 @@
 'extra_javascript':
   - 'js/externalLinkModal.js'
   - 'js/fixCreatedDate.js'
-  - 'js/termynal.min.js'
 'extra_css':
   - '/assets/stylesheets/extra.css'
   - '/assets/stylesheets/termynal.css'


### PR DESCRIPTION
We're not using any of the termynal animations, and, for the sake of performance, we don't need to either. So this PR removes the extra unnecessary JavaScript file.
Goes with: https://github.com/moondance-labs/tanssi-docs/pull/85