### PR TITLE
update code block styling

### DIFF
--- a/material-overrides/assets/stylesheets/tanssi.css
+++ b/material-overrides/assets/stylesheets/tanssi.css
@@ -1295,3 +1295,9 @@ h2.subtitle.mobile-subtitle {
   -webkit-mask-image: var(--md-admonition-icon--code);
   mask-image: var(--md-admonition-icon--code);
 }
+
+/* Styling to prevent code blocks from overlapping the Copy to Clipboard button */
+.md-typeset pre>code {
+  white-space: break-spaces;
+  padding-right: 3em;
+}


### PR DESCRIPTION
add styling to prevent code blocks from overlapping the Copy to Clipboard button

Before:
<img width="777" alt="Screenshot 2024-02-26 at 11 35 08 PM" src="https://github.com/papermoonio/tanssi-mkdocs/assets/26533957/24ec5aee-7ec2-4b00-b501-c532327e8ae5">

After:
<img width="785" alt="Screenshot 2024-02-26 at 11 34 14 PM" src="https://github.com/papermoonio/tanssi-mkdocs/assets/26533957/0d9f3026-29be-4e3a-9e30-7b59df75dd18">
