### PR TITLE
Fix text from overflowing outside of termynal snippets 

### DIFF
--- a/material-overrides/assets/stylesheets/tanssi.css
+++ b/material-overrides/assets/stylesheets/tanssi.css
@@ -402,7 +402,7 @@ li > nav.md-nav[data-md-level='4'] ul.md-nav__list {
 
 /* Add space below the section lines */
 .md-nav--primary .md-nav__list {
-  padding-bottom: 0;
+  padding-bottom: 0.01em;
   margin-bottom: 0.5em;
 }
 

--- a/material-overrides/assets/stylesheets/termynal.css
+++ b/material-overrides/assets/stylesheets/termynal.css
@@ -55,6 +55,7 @@
 [data-ty] {
   display: block;
   line-height: 1.25;
+  overflow-wrap: break-word;
 }
 
 [data-ty]:before {


### PR DESCRIPTION
This PR fixes a couple of things: prevents text from overflowing outside of termynal snippets and section titles from being cut off at the bottom.

Before:
<img width="867" alt="Screenshot 2024-02-28 at 5 48 18 PM" src="https://github.com/papermoonio/tanssi-mkdocs/assets/26533957/d5b5a065-cc04-40cc-9d32-35445c24070e">

After:
<img width="749" alt="Screenshot 2024-02-28 at 5 48 09 PM" src="https://github.com/papermoonio/tanssi-mkdocs/assets/26533957/ee5a98aa-439e-4f85-be25-449d2f492933">

-----

Before:
<img width="154" alt="Screenshot 2024-02-28 at 5 49 50 PM" src="https://github.com/papermoonio/tanssi-mkdocs/assets/26533957/c705f8c0-152f-4f49-aac6-bea2ec6bd0d0">

After:
<img width="149" alt="Screenshot 2024-02-28 at 5 50 03 PM" src="https://github.com/papermoonio/tanssi-mkdocs/assets/26533957/a25dffa8-2168-4fdb-bba0-9f8915609f3d">
