### PR TITLE
Update loading of the custom font and add google verification tag

### DIFF
--- a/material-overrides/assets/stylesheets/extra.css
+++ b/material-overrides/assets/stylesheets/extra.css
@@ -1,4 +1,5 @@
 @font-face {
     font-family: "Kilimanjaro Sans";
     src: url("fonts/Kilimanjaro-Sans.otf") format("opentype");
+    font-display: swap;
 }

--- a/material-overrides/main.html
+++ b/material-overrides/main.html
@@ -4,6 +4,7 @@
   {{ super() }}
     {% if page and page.meta and page.meta.keywords %}
       <meta name="keywords" content="{{ page.meta.keywords }}">
+      <meta name="google-site-verification" content="Owdrdc86b73FM35ZvpM4fiP-d5RcXz2uD9qSIsdXYKU" />
     {% endif %}
 {% endblock %}
 

--- a/material-overrides/main.html
+++ b/material-overrides/main.html
@@ -19,6 +19,11 @@
   {%- endif -%} 
 {%- endblock -%} 
 
+{% block fonts %}
+  {{ super() }}
+  <link rel="preload" href="/assets/stylesheets/fonts/Kilimanjaro-Sans.otf" as="font" type="font/otf">
+{% endblock %}
+
 {%- block container -%} 
   <div class="md-content" data-md-component="content">
     {% set class = "index-page" if not page.content and not page.is_homepage %}


### PR DESCRIPTION
This PR updates how the custom font, Kilimanjaro, is loaded. By preloading the font and also allowing a system font to be used while the custom font is being loaded, this should increase webfont load times and ensure that text remains visible during webfont load.

This PR also includes the addition of a Google verification meta tag, this will provide access to the Google search console, so we can gain additional insight into how the docs site is performing.