### PR TITLE
update expandable admonition styling

### DIFF
--- a/material-overrides/assets/stylesheets/tanssi.css
+++ b/material-overrides/assets/stylesheets/tanssi.css
@@ -365,6 +365,12 @@ a.md-header__button.md-logo img {
   }
 }
 
+@media screen and (min-width: 60em) {
+  .md-nav--secondary .md-nav__title {
+      box-shadow: unset;
+  }
+}
+
 /* Nav buttons styling */
 .md-header__button.md-typeset .md-button.join-community {
   padding: 0.75em;
@@ -515,6 +521,12 @@ li > nav.md-nav[data-md-level='4'] ul.md-nav__list {
   font-size: 0.8rem;
 }
 
+html .md-typeset details.function div.tabbed-set,
+.md-typeset .function p,
+.md-typeset .function .admonition {
+  margin: 1em 2em;
+}
+
 .md-typeset .function > summary::before {
   display: none;
 }
@@ -528,13 +540,9 @@ details.function .tabbed-set {
   margin: 1em 2em;
 }
 
-.function .tabbed-block p,
-.function .tabbed-block ul,
-.function .tabbed-block ol {
-  padding: 0 1em;
-}
-
-.function .tabbed-block .admonition {
+.md-typeset .function .tabbed-block p,
+.md-typeset .function .tabbed-block ul,
+.md-typeset .function .tabbed-block ol {
   margin: 1em;
 }
 


### PR DESCRIPTION
This PR updates the styling for elements inside of expandable admonitions so all elements vertically align. It also removes a box shadow from the TOC menu.

### Expandable Admonitions

Before:

<img width="760" alt="Screenshot 2024-07-26 at 11 36 53 AM" src="https://github.com/user-attachments/assets/a1fb71df-4e78-4f4d-8b1b-7c2e91881a65">

After:

<img width="750" alt="Screenshot 2024-07-26 at 11 33 23 AM" src="https://github.com/user-attachments/assets/63b7204c-374b-4337-a055-11570fe43b45">

### TOC Menu

Before:

<img width="241" alt="Screenshot 2024-07-26 at 11 36 14 AM" src="https://github.com/user-attachments/assets/6b8a33b6-d23a-4ec5-a3c5-8bb0021f60be">

After:

<img width="224" alt="Screenshot 2024-07-26 at 11 34 01 AM" src="https://github.com/user-attachments/assets/9f28d5a2-6d87-4b1f-9b3d-9757215ed9ea">

