### PR TITLE
Added mkdocs-jupyter to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ MarkupSafe==2.1.3
 mkdocs==1.5.3
 mkdocs-awesome-pages-plugin==2.9.2
 mkdocs-git-revision-date-localized-plugin==1.2.2
+mkdocs-jupyter==0.25.1
 mkdocs-macros-plugin==1.0.5
 mkdocs-macros-test==0.1.0 
 mkdocs-material==9.5.3


### PR DESCRIPTION
The kluster.ai project requires the mkdocs-jupyter plugin. Since mkdocs requirements are deployed globally and affect all other mkdocs projects on the server, the requirements.txt files for all other projects must include this plugin as well.