### PR TITLE
Pillow Update

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ mkdocs-material-extensions==1.3.1
 mkdocs-minify-plugin==0.7.2
 mkdocs-redirects==1.2.1
 nltk==3.8.1
-Pillow==9.4.0
+Pillow==11.1.0
 Pygments==2.17.2
 pymdown-extensions==10.7
 python-dateutil==2.8.2


### PR DESCRIPTION
Updated Pillow to version 11.1 for compatibility with Python 3.13
This Pillow version is compatible for 3.9<= Python <=3.13 .