### PR TITLE
adds timeline element, still needs styling set up before use

### DIFF
--- a/material-overrides/assets/stylesheets/timeline-neoteroi.css
+++ b/material-overrides/assets/stylesheets/timeline-neoteroi.css
@@ -1,0 +1,1 @@
+/* TODO: add styling */

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,6 +11,7 @@ extra_javascript:
 extra_css:
   - /assets/stylesheets/tanssi.css
   - /assets/stylesheets/termynal.css
+  - /assets/stylesheets/timeline-neoteroi.css
 theme:
   name: material
   custom_dir: material-overrides
@@ -33,6 +34,7 @@ markdown_extensions:
   - codehilite
   - md_in_html
   - meta
+  - neoteroi.timeline
   - pymdownx.details
   - pymdownx.emoji:
       emoji_index: !!python/name:material.extensions.emoji.twemoji

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,7 @@ mkdocs-material==9.5.3
 mkdocs-material-extensions==1.3.1
 mkdocs-minify-plugin==0.7.2
 mkdocs-redirects==1.2.1
+neoteroi-mkdocs==1.1.0
 nltk==3.8.1
 Pillow==11.1.0
 Pygments==2.17.2


### PR DESCRIPTION
This PR adds the [timeline](https://www.neoteroi.dev/mkdocs-plugins/timeline/) element to the Tanssi documentation site. I need to set up styling (which will happen in a separate PR) before the timeline can be used. I did add a placeholder empty CSS file so I could point to it from mkdocs.yml. Thanks! 