### PR TITLE
update .urlignore

### DIFF
--- a/.urlignore
+++ b/.urlignore
@@ -15,3 +15,7 @@ https://twitter.com/
 
 # Error 500
 https://metamask.io/
+
+# Ignore known working URLs
+https://dancelight.subscan.io/
+https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_accounts


### PR DESCRIPTION
This pull request updates the `.urlignore` file to include additional URLs that should be ignored during checks. These URLs are known to be working and are added to streamline the process.

I checked both using curl and with SSL Labs, and both came out OK (200).

* [`.urlignore`](diffhunk://#diff-525d875490887fc8f77ab31d5042dd10415043aefbe000e5290b8a7419730104R18-R21): Added `https://dancelight.subscan.io/` and `https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_accounts` to the list of ignored URLs.