### PR TITLE
Add New URL in .urlignore

### DIFF
--- a/.urlignore
+++ b/.urlignore
@@ -15,3 +15,6 @@ https://twitter.com/
 
 # Error 500
 https://metamask.io/
+
+# Ignore known working URLs
+https://ethereum.org/


### PR DESCRIPTION
This pull request updates the `.urlignore` file to include a new URL under the "Ignore known working URLs" section.

* [`.urlignore`](diffhunk://#diff-525d875490887fc8f77ab31d5042dd10415043aefbe000e5290b8a7419730104R18-R20): Added `https://ethereum.org/` to the list of ignored URLs.